### PR TITLE
Bump google_api_client version from 4.2 to 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Document installation steps.
 Module is dependant on Drupal Google API PHP Client https://www.drupal.org/project/google_api_client for Google Oath2 Authentication.
 
 #### Install Google API Client:
-1. `$ composer require 'drupal/google_api_client:^4.2'`
+1. `$ composer require 'drupal/google_api_client:^4.3'`
 2. `$ drush en google_api_client`
 
 See Also:

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         }
     ],
     "require": {
-       "drupal/google_api_client": "^4.2"
+       "drupal/google_api_client": "^4.3"
     }
 }


### PR DESCRIPTION
farm_calendar_events v0.0.1-alpha tagged on September 15, 2022 = https://github.com/Farmer-Eds-Shed/farm_calendar_events/releases/tag/v0.0.1-alpha

google_api_client 4.3 was released on September 21, 2022 = https://www.drupal.org/project/google_api_client/releases/8.x-4.3

I’ve been using 4.3 for quite a while now and it works just fine.